### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/job2.yml
+++ b/.github/workflows/job2.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         docker build -t jrwtango/expressimage .
     - name: expressimage
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: jrwtango/expressimage
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore